### PR TITLE
Ensure WordSphere main container fills the viewport

### DIFF
--- a/tools/wordsphere/index.html
+++ b/tools/wordsphere/index.html
@@ -37,12 +37,16 @@
             overflow: hidden;
         }
 
+        #main-container,
         #alt-container {
             width: 100vw;
             height: 100vh;
-            display: none;
             position: relative;
             overflow: hidden;
+        }
+
+        #alt-container {
+            display: none;
             background-color: #0a0a1a;
             background: radial-gradient(circle at center, #1a1a2a 0%, #0a0a1a 100%);
         }


### PR DESCRIPTION
## Summary
- ensure the primary WordSphere container has explicit dimensions so the SVG can size correctly
- preserve the alternate view background styling while keeping it hidden by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa98a8e8708321b9d9afc55c1d74cc